### PR TITLE
fix: default adr template in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -18,8 +18,11 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 # RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1
 
 COPY setup_tools.sh /tmp/setup_tools.sh
-RUN chmod +x /tmp/setup_tools.sh && su vscode -c "/tmp/setup_tools.sh"
+RUN chmod +x /tmp/setup_tools.sh && su - vscode -c "/tmp/setup_tools.sh"
 
 # This must be last in the .bashrc to ensure the paths are adjusted earlier
 COPY _dotnet_bash_complete.sh /tmp/_dotnet_bash_complete.sh
-RUN su vscode -c "cat /tmp/_dotnet_bash_complete.sh >> /home/vscode/.bashrc"
+RUN su - vscode -c "cat /tmp/_dotnet_bash_complete.sh >> /home/vscode/.bashrc"
+
+COPY post_start_command.sh /home/vscode/post_start_command.sh
+RUN chmod +x /home/vscode/post_start_command.sh

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,7 +31,7 @@
     // Use 'postCreateCommand' to run commands after the container is created.
     // "postCreateCommand": "dotnet restore",
     // Find all fsproj files and dotnet restore them
-    "postStartCommand": "find ./ -type f -name \"*.fsproj\" -print0 | xargs -r0 /bin/bash -c 'for f in \"$@\"; do echo \"$f\"; dotnet restore \"$f\"; done;' ''",
+    "postStartCommand": "/home/vscode/post_start_command.sh",
 
     // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
     "remoteUser": "vscode",

--- a/.devcontainer/post_start_command.sh
+++ b/.devcontainer/post_start_command.sh
@@ -1,0 +1,1 @@
+find ./ -type f -name "*.fsproj" -print0 | xargs -r0 /bin/bash -c 'for f in "$@"; do echo "$f"; dotnet restore "$f"; done;' ''

--- a/.devcontainer/setup_tools.sh
+++ b/.devcontainer/setup_tools.sh
@@ -2,15 +2,24 @@
 source /usr/local/share/nvm/nvm.sh
 # Install npm globals
 npm install -g yo generator-code vsce
+
 # Install dotnet global tools
-PATH=/home/vscode/.dotnet/tools:$PATH
+echo "export PATH=$PATH:~/.dotnet/tools" >> /home/vscode/.bashrc
+PATH=$PATH:~/.dotnet/tools
+echo 
 dotnet new --install Fable.Template
 dotnet tool install dotnet-suggest --global
 dotnet tool install paket --global
 dotnet tool install fable --global
 dotnet tool install femto --global
-# no stable version of the adr tool available yet available yet \n\
-dotnet tool install adr --global --version 0.1.0-preview.36
-adr templates default set madr
 
-echo "export PATH=$PATH" >> /home/vscode/.bashrc
+# ADR tool
+# no stable version of the adr tool available yet
+dotnet tool install adr --global --version 0.1.0-preview.36 
+
+# Setup default adr template
+# Make sure .config exists in the home folder.  If .config doesn't exist yet,
+# the adr config ends up in $HOME/endjin which doesn't work once we're in the
+# container, because by then .config _does_ exist
+mkdir -p $HOME/.config
+adr templates default set madr


### PR DESCRIPTION
Resolve adr template default setting by ensuring `/home/vscode/.config` exists in advance, and running scripts with  to ensure profile env variables are loaded.