### PR TITLE
Fix/handle invalid definitions

### DIFF
--- a/src/Contextly.LanguageServer.Tests/Completion.fs
+++ b/src/Contextly.LanguageServer.Tests/Completion.fs
@@ -1,0 +1,31 @@
+module Contextly.LanguageServer.Tests.Completion
+
+open OmniSharp.Extensions.LanguageServer.Protocol.Client
+open OmniSharp.Extensions.LanguageServer.Protocol.Document
+open OmniSharp.Extensions.LanguageServer.Protocol.Models
+
+let getLabels (result:CompletionList) = 
+    result.Items |> Seq.map (fun x -> x.Label)
+
+let getCompletionFromText (text: string) (uri:string) (position:Position) (client:ILanguageClient)  = async {
+    client.TextDocument.DidOpenTextDocument(DidOpenTextDocumentParams(TextDocument = TextDocumentItem(
+        LanguageId = "plaintext",
+        Version = 0,
+        Text = text,
+        Uri = uri
+    )))
+
+    let completionParams = CompletionParams(
+        TextDocument = uri,
+        Position = position
+    )
+
+    return! client.TextDocument.RequestCompletion(completionParams).AsTask() |> Async.AwaitTask
+}
+
+let getCompletion = getCompletionFromText "" $"file:///{System.Guid.NewGuid().ToString()}" <| Position(0,0)
+
+let getCompletionLabels (client:ILanguageClient) = async {
+    let! result = getCompletion client
+    return getLabels result
+}

--- a/src/Contextly.LanguageServer.Tests/ConfigurationSection.fs
+++ b/src/Contextly.LanguageServer.Tests/ConfigurationSection.fs
@@ -48,3 +48,12 @@ let mapLoader (pathLoader:PathLoader) () = Map[("path", pathLoader())]
 let contextlyPathLoaderOptionsBuilder (pathLoader:PathLoader) = optionsBuilder "contextly" <| mapLoader pathLoader
 
 let contextlyPathOptionsBuilder path = contextlyPathLoaderOptionsBuilder (fun () -> path)
+
+let didChange (client:ILanguageClient) path =
+    let setting = jTokenFromMap <| Map[("path", path)]
+    let configSection = jTokenFromMap <| Map[("contextly", setting)]
+
+    let didChangeConfig = DidChangeConfigurationParams(
+        Settings = configSection
+    )
+    client.Workspace.DidChangeConfiguration(didChangeConfig)

--- a/src/Contextly.LanguageServer.Tests/ConfigurationTests.fs
+++ b/src/Contextly.LanguageServer.Tests/ConfigurationTests.fs
@@ -4,30 +4,6 @@ open Expecto
 open Swensen.Unquote
 open System.IO
 open TestClient
-open OmniSharp.Extensions.LanguageServer.Protocol.Client
-open OmniSharp.Extensions.LanguageServer.Protocol.Workspace
-open OmniSharp.Extensions.LanguageServer.Protocol.Document
-open OmniSharp.Extensions.LanguageServer.Protocol.Models
-
-let getCompletionLabels (client:ILanguageClient) = async {
-    let textDocumentUri = $"file:///{System.Guid.NewGuid().ToString()}"
-
-    client.TextDocument.DidOpenTextDocument(DidOpenTextDocumentParams(TextDocument = TextDocumentItem(
-        LanguageId = "plaintext",
-        Version = 0,
-        Text = "",
-        Uri = textDocumentUri
-    )))
-
-    let completionParams = CompletionParams(
-        TextDocument = textDocumentUri,
-        Position = Position(0, 0)
-    )
-
-    let! result = client.TextDocument.RequestCompletion(completionParams).AsTask() |> Async.AwaitTask
-
-    return (result.Items |> Seq.map (fun x -> x.Label))
-}
 
 [<Tests>]
 let definitionsTests =
@@ -40,7 +16,7 @@ let definitionsTests =
 
             use! client = TestClient(config) |> init
 
-            let! completionLabels = getCompletionLabels client
+            let! completionLabels = Completion.getCompletionLabels client
 
             test <@ (completionLabels, ["firstTerm";"secondTerm";"thirdTerm"]) ||> Seq.compareWith compare = 0 @>
         }
@@ -58,17 +34,9 @@ let definitionsTests =
             use! client = TestClient(config) |> init
 
             path <- "two.yml"
+            ConfigurationSection.didChange client path
 
-            let setting = ConfigurationSection.jTokenFromMap <| Map[("path", path)]
-            let configSection = ConfigurationSection.jTokenFromMap <| Map[("contextly", setting)]
-
-            let didChangeConfig = DidChangeConfigurationParams(
-                Settings = configSection
-            )
-
-            client.Workspace.DidChangeConfiguration(didChangeConfig)
-
-            let! completionLabels = getCompletionLabels client
+            let! completionLabels = Completion.getCompletionLabels client
 
             test <@ (completionLabels, ["word1";"word2";"word3"]) ||> Seq.compareWith compare = 0 @>
 

--- a/src/Contextly.LanguageServer.Tests/Contextly.LanguageServer.Tests.fsproj
+++ b/src/Contextly.LanguageServer.Tests/Contextly.LanguageServer.Tests.fsproj
@@ -6,12 +6,13 @@
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Completion.fs" />
     <Compile Include="ConditionAwaiter.fs" />
     <Compile Include="WatchedFiles.fs" />
     <Compile Include="ServerLog.fs" />
     <Compile Include="Workspace.fs" />
-    <Compile Include="ConfigurationSection.fs" />
     <Compile Include="TestClient.fs" />
+    <Compile Include="ConfigurationSection.fs" />
     <Compile Include="ConfigurationTests.fs" />
     <Compile Include="DefinitionsTests.fs" />
     <Compile Include="WatchedFilesTests.fs" />

--- a/src/Contextly.LanguageServer.Tests/Contextly.LanguageServer.Tests.fsproj
+++ b/src/Contextly.LanguageServer.Tests/Contextly.LanguageServer.Tests.fsproj
@@ -32,6 +32,12 @@
     <Content Include="fixtures/completion_tests/three.yml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="fixtures/completion_tests/invalid_schema.yml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="fixtures/completion_tests/invalid_empty.yml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />

--- a/src/Contextly.LanguageServer.Tests/Contextly.LanguageServer.Tests.fsproj
+++ b/src/Contextly.LanguageServer.Tests/Contextly.LanguageServer.Tests.fsproj
@@ -12,8 +12,8 @@
     <Compile Include="Workspace.fs" />
     <Compile Include="ConfigurationSection.fs" />
     <Compile Include="TestClient.fs" />
-    <Compile Include="DefinitionsTests.fs" />
     <Compile Include="ConfigurationTests.fs" />
+    <Compile Include="DefinitionsTests.fs" />
     <Compile Include="WatchedFilesTests.fs" />
     <Compile Include="TextDocumentTests.fs" />
     <Compile Include="CompletionTests.fs" />

--- a/src/Contextly.LanguageServer.Tests/DefinitionsTests.fs
+++ b/src/Contextly.LanguageServer.Tests/DefinitionsTests.fs
@@ -4,9 +4,6 @@ open Expecto
 open Swensen.Unquote
 open System.IO
 open Contextly.LanguageServer
-open TestClient
-open OmniSharp.Extensions.LanguageServer.Protocol.Workspace
-open OmniSharp.Extensions.LanguageServer.Protocol.Models
 
 [<Tests>]
 let definitionsTests =

--- a/src/Contextly.LanguageServer.Tests/DefinitionsTests.fs
+++ b/src/Contextly.LanguageServer.Tests/DefinitionsTests.fs
@@ -9,37 +9,65 @@ open Contextly.LanguageServer
 let definitionsTests =
     testList "Definitions File Tests" [
 
-        let getTermsFromFile() = async {
-            let path = Path.Combine("fixtures", "completion_tests", "one.yml") |> Some
-            let workspaceFolder = Some ""
+        let getDefinitions configGetter workspaceFolder = async {
             let definitions = Definitions.create()
-            Definitions.init definitions (fun _ -> ()) (fun _ -> async.Return path) None
+            Definitions.init definitions (fun _ -> ()) configGetter None
             Definitions.addFolder definitions workspaceFolder
             (Definitions.loader definitions)()
+            return definitions
+        }
+
+        let getFileName fileName = Path.Combine("fixtures", "completion_tests", $"{fileName}.yml") |> Some
+
+        let getTermsFromFile fileName = async {
+            let path = getFileName fileName
+            let workspaceFolder = Some ""
+            let configGetter = (fun _ -> async.Return path)
+            let! definitions = getDefinitions configGetter workspaceFolder
             return! Definitions.find definitions (fun _ -> true)
         }
 
         let compareList = Seq.compareWith compare
 
+        let oneExpectedNames = seq ["firstTerm"; "secondTerm"; "thirdTerm"]
+
         testAsync "Can load term Names" {
-            let! terms = getTermsFromFile()
+            let! terms = getTermsFromFile "one"
             let foundNames = terms |> Seq.map (fun t -> t.Name)
-            let expectedNames = seq ["firstTerm"; "secondTerm"; "thirdTerm"]
-            test <@ (foundNames, expectedNames) ||> compareList = 0 @>
+            test <@ (foundNames, oneExpectedNames) ||> compareList = 0 @>
         }
 
         testAsync "Can load term Definitions" {
-            let! terms = getTermsFromFile()
+            let! terms = getTermsFromFile "one"
             let foundDefinitions = terms |> Seq.map (fun t -> t.Definition) |> Seq.choose id
             let expectedDefinitions = seq ["The first term in our definitions list"; "The second term in our definitions list"]
             test <@ (foundDefinitions, expectedDefinitions) ||> compareList = 0 @>
         }
 
         testAsync "Can load term UsageExamples" {
-            let! terms = getTermsFromFile()
+            let! terms = getTermsFromFile "one"
             let foundDefinitions = terms |> Seq.map (fun t -> t.Examples) |> Seq.filter ((<>) null) |> Seq.map Seq.cast
             let expectedDefinitions = seq [seq ["An arbitrary usage of secondTerm";"Don't forget to secondTerm the firstTerms"]]
             test <@ (foundDefinitions, expectedDefinitions) ||> Seq.compareWith compareList = 0 @>
+        }
+
+        testAsync "Can recover from invalid definitions" {
+            let mutable path = getFileName "invalid"
+            let workspaceFolder = Some ""
+            let configGetter = (fun _ -> async.Return path)
+
+            let! definitions = getDefinitions configGetter workspaceFolder
+            let! termsWhenInvalid = Definitions.find definitions (fun _ -> true)
+
+            test <@ Seq.length termsWhenInvalid = 0 @>
+
+            path <- getFileName "one"
+            (Definitions.loader definitions)()
+
+            let! termsWhenValid = Definitions.find definitions (fun _ -> true)
+            let foundNames = termsWhenValid |> Seq.map (fun t -> t.Name)
+
+            test <@ (foundNames, oneExpectedNames) ||> compareList = 0 @>
         }
 
     ]

--- a/src/Contextly.LanguageServer.Tests/WatchedFilesTests.fs
+++ b/src/Contextly.LanguageServer.Tests/WatchedFilesTests.fs
@@ -108,7 +108,7 @@ let watchedFileTests =
             
             let! completionLabels = Completion.getCompletionLabels client
 
-            File.Delete(definitionsFile)
+            File.Delete(definitionsFileUri)
 
             test <@ completionLabels |> Seq.contains "anewterm" @>
         }

--- a/src/Contextly.LanguageServer.Tests/fixtures/completion_tests/invalid_schema.yml
+++ b/src/Contextly.LanguageServer.Tests/fixtures/completion_tests/invalid_schema.yml
@@ -1,0 +1,7 @@
+# Invalid definitions.  `example` is an unknown key - it should be `examples`
+contexts:
+  - terms:
+    - name: invalidTerm
+      definition: A term with an invalid schema in the definitions.yml
+      example:
+        - This should be in the `examples` key.

--- a/src/Contextly.LanguageServer/Definitions.fs
+++ b/src/Contextly.LanguageServer/Definitions.fs
@@ -49,7 +49,6 @@ let private deserialize (yml:string) =
         | _ -> Some definitions
     with
     | e -> 
-        printfn "%A" e
         None
 
 let private loadContextly path =
@@ -77,71 +76,117 @@ type private State =
     {
         WorkspaceFolder: string option
         Logger: (string -> unit)
+        DefinitionsFilePath: string option
         Definitions: Definitions
         ConfigGetter: (unit -> Async<string option>)
         RegisterWatchedFile: (string option -> Unregisterer) option
         UnregisterLastWatchedFile: Unregisterer option
+        OnErrorLoading: (string -> unit)
     }
     static member Initial() = { 
         WorkspaceFolder = None;
         Logger = fun _ -> ();
+        DefinitionsFilePath = None;
         Definitions = Definitions.Default;
         ConfigGetter = fun () -> async.Return None;
         RegisterWatchedFile = None
         UnregisterLastWatchedFile = None
+        OnErrorLoading = fun _ -> ();
     }
 
 type LoadReply = string option
 
 type Message =
-    | Init of logger: (string -> unit) * configGetter: (unit -> Async<string option>) * registerWatchedFile: (string option -> Unregisterer) option
+    | Init of
+        logger: (string -> unit) *
+        configGetter: (unit -> Async<string option>) *
+        registerWatchedFile: (string option -> Unregisterer) option *
+        onErrorLoading: (string -> unit)
     | AddFolder of workspaceFolder: string option
     | Load
     | Find of filter: Filter * replyChannel: AsyncReplyChannel<Term seq>
 
-let create() = MailboxProcessor.Start(fun inbox -> 
-    let rec loop (state: State) = async {
-        let! (msg: Message) = inbox.Receive()
-        let! newState =
-            match msg with
-            | Init(logger, configGetter, registerWatchedFile) -> async.Return { 
+let private handleMessage (state: State) (msg: Message) = async {
+    return! match msg with
+            | Init(logger, configGetter, registerWatchedFile, onErrorLoading) -> async.Return { 
                 state with
-                    Logger = logger;
+                    Logger = fun msg -> 
+                                async {
+                                    logger msg
+                                } |> Async.Start
                     ConfigGetter = configGetter;
                     RegisterWatchedFile = registerWatchedFile
+                    OnErrorLoading = onErrorLoading;
                 }
             | AddFolder(workspaceFolder) -> async.Return { state with WorkspaceFolder = workspaceFolder }
             | Load -> async {
                     let! path = state.ConfigGetter()
                     let absolutePath = getPath state.WorkspaceFolder path
-                    let defs = loadFromPath absolutePath
-                    let newState = match defs with 
-                                    | Some d -> { state with Definitions = d }
-                                    | _ -> { state with Definitions = Definitions.Default }
+
                     match absolutePath with
-                    | Some ap -> state.Logger $"Loading contextly from {ap}"
+                    | Some ap -> state.Logger $"Loading contextly from {ap}..."
                     | None -> ()
-                    match state.UnregisterLastWatchedFile with
-                    | Some unregister -> unregister()
-                    | None -> ()                    
-                    let unregisterer =
-                        match state.RegisterWatchedFile with
-                        | Some rwf -> rwf absolutePath |> Some
-                        | None -> None
-                    return { newState with UnregisterLastWatchedFile = unregisterer }
+
+                    state.Logger $"Load from path {absolutePath}..."
+                    let defs = loadFromPath absolutePath
+                    state.Logger $"Returned defs {defs}..."
+                    let newState = 
+                        match defs with 
+                        | Some d -> { state with Definitions = d }
+                        | _ -> { state with Definitions = Definitions.Default }
+                    state.Logger $"newState {newState}..."
+                    
+                    match absolutePath, defs with
+                    | Some _, Some _ -> state.Logger "Succesfully loaded."
+                    | Some ap, None -> state.Logger $"Error loading definitions.  Please check syntax in {ap}"
+                    | _, _ -> ()
+
+                    let returnState = 
+                        match state.DefinitionsFilePath, absolutePath with
+                        | Some existingPath, Some newPath when existingPath = newPath -> newState
+                        | _, _ -> 
+                            match state.UnregisterLastWatchedFile with
+                            | Some unregister -> 
+                                state.Logger $"Unwatching {state.DefinitionsFilePath}."
+                                unregister()
+                            | None -> ()
+
+                            let unregisterer =
+                                match state.RegisterWatchedFile with
+                                | Some rwf -> 
+                                    state.Logger $"Watching {absolutePath}."
+                                    rwf absolutePath |> Some
+                                | None -> None
+
+                            { newState with UnregisterLastWatchedFile = unregisterer; DefinitionsFilePath = absolutePath }
+                    state.Logger $"About to return state {returnState}"
+                    return returnState
+                    
                 }
             | Find(filter, replyChannel) ->
                 let foundTerms = state.Definitions.Contexts |> Seq.collect(fun c -> c.Terms) |> Seq.filter filter
                 replyChannel.Reply foundTerms
                 async.Return state
+}
 
+let create() = MailboxProcessor.Start(fun inbox -> 
+    let rec loop (state: State) = async {
+        let! (msg: Message) = inbox.Receive()
+        let! newState =
+            try
+                handleMessage state msg
+            with
+                | e -> 
+                    printfn "%A" e
+                    state.Logger <| e.ToString()
+                    async.Return state
         return! loop newState
     }
     loop <| State.Initial()
 )
 
-let init (definitionsManager:MailboxProcessor<Message>) logger configGetter registerWatchedFiles = 
-    Init(logger, configGetter, registerWatchedFiles) |> definitionsManager.Post
+let init (definitionsManager:MailboxProcessor<Message>) logger configGetter registerWatchedFiles onErrorLoading = 
+    Init(logger, configGetter, registerWatchedFiles, onErrorLoading) |> definitionsManager.Post
 
 let addFolder (definitionsManager:MailboxProcessor<Message>) workspaceFolder = 
     AddFolder(workspaceFolder) |> definitionsManager.Post
@@ -150,4 +195,5 @@ let loader (definitionsManager:MailboxProcessor<Message>) = fun () ->
     Load |> definitionsManager.Post
 
 let find (definitionsManager:MailboxProcessor<Message>) (filter:Filter) =
-    definitionsManager.PostAndAsyncReply <| fun rc -> Find(filter, rc)
+    let msgBuilder = fun rc -> Find(filter, rc)
+    definitionsManager.PostAndAsyncReply(msgBuilder, 1000)

--- a/src/Contextly.LanguageServer/Definitions.fs
+++ b/src/Contextly.LanguageServer/Definitions.fs
@@ -43,7 +43,10 @@ let private deserialize (yml:string) =
             (new DeserializerBuilder())
                 .WithNamingConvention(CamelCaseNamingConvention.Instance)
                 .Build()
-        deserializer.Deserialize<Definitions>(yml) |> Some
+        let definitions = deserializer.Deserialize<Definitions>(yml)
+        match definitions |> box with
+        | null -> None
+        | _ -> Some definitions
     with
     | e -> 
         printfn "%A" e

--- a/src/Contextly.LanguageServer/Definitions.fs
+++ b/src/Contextly.LanguageServer/Definitions.fs
@@ -166,7 +166,7 @@ module private Handle =
                                     let msg = $"Error loading definitions: {msg}"
                                     state.Logger msg
                                     state.OnErrorLoading msg
-                                    state
+                                    { state with Definitions = Definitions.Default }
                             | None -> state
 
             return updateFileWatchers newState absolutePath

--- a/src/Contextly.LanguageServer/Server.fs
+++ b/src/Contextly.LanguageServer/Server.fs
@@ -7,7 +7,6 @@ open OmniSharp.Extensions.LanguageServer.Protocol.Models
 open OmniSharp.Extensions.LanguageServer.Protocol.Window
 open OmniSharp.Extensions.LanguageServer.Protocol.Workspace
 open OmniSharp.Extensions.LanguageServer.Protocol.Document
-open OmniSharp.Extensions.LanguageServer.Protocol
 open Microsoft.Extensions.Logging
 open Serilog
 open System.IO

--- a/src/Contextly.LanguageServer/Server.fs
+++ b/src/Contextly.LanguageServer/Server.fs
@@ -7,6 +7,7 @@ open OmniSharp.Extensions.LanguageServer.Protocol.Models
 open OmniSharp.Extensions.LanguageServer.Protocol.Window
 open OmniSharp.Extensions.LanguageServer.Protocol.Workspace
 open OmniSharp.Extensions.LanguageServer.Protocol.Document
+open OmniSharp.Extensions.LanguageServer.Protocol
 open Microsoft.Extensions.Logging
 open Serilog
 open System.IO
@@ -49,8 +50,8 @@ let private onStartup definitions = OnLanguageServerStartedDelegate(fun (s:ILang
         let definitionsLoader = Definitions.loader definitions
 
         let registerWatchedFiles = Some <| WatchedFiles.register s definitionsLoader
-
-        Definitions.init definitions s.Window.LogInfo configGetter registerWatchedFiles
+       
+        Definitions.init definitions s.Window.LogInfo configGetter registerWatchedFiles s.Window.ShowWarning
         Definitions.addFolder definitions workspaceFolder
       
         definitionsLoader()

--- a/src/vscode/contextly/README.md
+++ b/src/vscode/contextly/README.md
@@ -31,7 +31,7 @@ Use the `Contextly: Initialize Definitions` command from the command palette to 
 
 This extension contributes the following settings:
 
-* `contextly.path`: The path of the `contextly.yml` file that stores the Contextly definitions.  Default: `.contextly/definitions.yml`
+* `contextly.path`: The path of the file that stores the Contextly definitions.  Default: `.contextly/definitions.yml`
 
 ## Known Issues
 

--- a/src/vscode/contextly/src/Contextly.VsCodeExtension.fsproj
+++ b/src/vscode/contextly/src/Contextly.VsCodeExtension.fsproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <OtherFlags>--nowarn:46</OtherFlags>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\..\paket-files\ionide\ionide-vscode-helpers\src\Fable.Import.VSCode.fs">

--- a/src/vscode/contextly/test/Completion.test.fs
+++ b/src/vscode/contextly/test/Completion.test.fs
@@ -32,13 +32,14 @@ let expectCompletion path position expectedResults (onBeforeAssert : (unit -> JS
         Expect.isSome result "executeCompletionItemProvider should return a result"
 }
 
+let DefaultExpectedTerms = seq {"context"; "definition"; "example"; "term"}
+
 let tests =
     testList "Contextly Completion Tests" [
 
         testCaseAsync "Completion returns expected list" <| async {
             let testDocPath = "../test/fixtures/simple_workspace/test.txt"
             let position = vscode.Position.Create(0.0, 10.0)
-            let expectedResults = seq {"context"; "definition"; "example"; "term"}
-            do! expectCompletion testDocPath position expectedResults None
+            do! expectCompletion testDocPath position DefaultExpectedTerms None
         }
     ]

--- a/src/vscode/contextly/test/Contextly.VsCodeExtension.Tests.fsproj
+++ b/src/vscode/contextly/test/Contextly.VsCodeExtension.Tests.fsproj
@@ -14,6 +14,7 @@
     <Compile Include="VsCodeCommands.fs" />
     <Compile Include="Completion.test.fs" />
     <Compile Include="Initialize.test.fs" />
+    <Compile Include="InvalidSchema.test.fs" />
     <Compile Include="Extension.test.fs" />
     <Compile Include="Main.test.fs" />
   </ItemGroup>

--- a/src/vscode/contextly/test/Helpers.fs
+++ b/src/vscode/contextly/test/Helpers.fs
@@ -4,6 +4,7 @@ open Contextly.VsCodeExtension
 open Fable.Import.VSCode
 open Fable.Import.VSCode.Vscode
 open Node.Api
+open Fable.Core
 
 let getDocUri relativeFile =
     vscode.Uri.file(path.resolve(__dirname,relativeFile))
@@ -20,3 +21,37 @@ let closeDocument (docUri:Uri) = promise {
     do! commands.executeCommand("workbench.action.closeActiveEditor") |> Thenable.Ignore
     return ()
 }
+
+let getConfig() = workspace.getConfiguration("contextly")
+
+let getFullPathFromConfig() =
+    let config = getConfig()
+    let path = config["path"].Value :?> string
+    let wsf = workspace.workspaceFolders.Value[0]
+    vscode.Uri.joinPath(wsf.uri, [|path|])
+
+let findUriInVisibleEditors (path:Uri) =
+    window.visibleTextEditors.Find(fun te -> te.document.uri.path = path.path)
+
+let updateConfig newPath = promise {
+    let config = getConfig()
+    do! config.update("path", newPath :> obj |> Some)
+    do! Promise.sleep 10
+}
+
+let resetConfig() = promise {
+    let config = getConfig()
+    do! config.update("path", None)
+}
+
+let deleteDefinitionsFile() = promise {
+    let fullPath = getFullPathFromConfig()
+    do! closeDocument fullPath |> Promise.Ignore
+    do! workspace.fs.delete fullPath
+}
+
+[<Emit("afterEach($0, $1)")>]
+let afterEach (name: string, callback: unit -> JS.Promise<unit>):unit = jsNative
+
+[<Emit("after($0, $1)")>]
+let after (name: string, callback: unit -> JS.Promise<unit>):unit = jsNative

--- a/src/vscode/contextly/test/Initialize.test.fs
+++ b/src/vscode/contextly/test/Initialize.test.fs
@@ -5,23 +5,44 @@ open Fable.Import.VSCode
 open Fable.Import.VSCode.Vscode
 open Contextly.VsCodeExtension.Tests.Helpers
 
+let getConfig() = workspace.getConfiguration("contextly")
+
+let getFullPathFromConfig() =
+    let config = getConfig()
+    let path = config["path"].Value :?> string
+    let wsf = workspace.workspaceFolders.Value[0]
+    vscode.Uri.joinPath(wsf.uri, [|path|])
+
+let findUriInVisibleEditors (path:Uri) =
+    window.visibleTextEditors.Find(fun te -> te.document.uri.path = path.path)
+
+let updateConfig newPath = promise {
+    let config = getConfig()
+    do! config.update("path", newPath :> obj |> Some)
+    do! Promise.sleep 10
+}
+
+let resetConfig() = promise {
+    let config = getConfig()
+    do! config.update("path", None)
+}
+
+let resetDefinitionsFile fullPath = promise {
+    do! closeDocument fullPath |> Promise.Ignore
+    do! workspace.fs.delete fullPath
+}
+
+let resetWorkspace fullPath = promise {
+    do! resetConfig()
+    do! resetDefinitionsFile fullPath
+}
+
 let tests =
     testList "Initialize Tests" [
         testCaseAsync "Extension has Initialize Project Command" <| async {
             let! registeredCommands = commands.getCommands(false)
             Expect.exists registeredCommands (fun c -> c = "contextly.initialize") "Initialize command doesn't exist"
         }
-
-        let getConfig() = workspace.getConfiguration("contextly")
-
-        let getFullPathFromConfig() =
-            let config = getConfig()
-            let path = config["path"].Value :?> string
-            let wsf = workspace.workspaceFolders.Value[0]
-            vscode.Uri.joinPath(wsf.uri, [|path|])
-
-        let findUriInVisibleEditors (path:Uri) =
-            window.visibleTextEditors.Find(fun te -> te.document.uri.path = path.path)
 
         testCaseAsync "Initialize Command should open existing definitions.yml" <| async {
             do! VsCodeCommands.initialize() |> Promise.Ignore
@@ -33,27 +54,6 @@ let tests =
             do! closeDocument fullPath |> Promise.Ignore
 
             Expect.isNotNull editor "Existing definitions.yml isn't open"
-        }
-
-        let updateConfig newPath = promise {
-            let config = getConfig()
-            do! config.update("path", newPath :> obj |> Some)
-            do! Promise.sleep 10
-        }
-
-        let resetConfig() = promise {
-            let config = getConfig()
-            do! config.update("path", None)
-        }
-
-        let resetDefinitionsFile fullPath = promise {
-            do! closeDocument fullPath |> Promise.Ignore
-            do! workspace.fs.delete fullPath
-        }
-
-        let resetWorkspace fullPath = promise {
-            do! resetConfig()
-            do! resetDefinitionsFile fullPath
         }
 
         testCaseAsync "Initialize Command should open new definitions.yml" <| async {

--- a/src/vscode/contextly/test/InvalidSchema.test.fs
+++ b/src/vscode/contextly/test/InvalidSchema.test.fs
@@ -2,26 +2,20 @@ module Contextly.VsCodeExtension.Tests.InvalidSchema
 
 open Fable.Mocha
 open Fable.Import.VSCode
-open Initialize
+open Helpers
 
 let tests =
     testList "Invalid Schema Tests" [
         testCaseAsync "Should recover from an invalid schema" <| async {
-            let newPath = $".contextly/invalid_schema.yml"
-            do! updateConfig newPath
-
-            do! VsCodeCommands.initialize() |> Promise.Ignore
-            
-            do! Promise.sleep 500
-
-            let resetWorkspaceHook = Some (fun _ -> promise {do! resetConfig()})
+            do! updateConfig ".contextly/invalid_schema.yml"
 
             let testDocPath = "../test/fixtures/simple_workspace/test.txt"
             let position = vscode.Position.Create(0.0, 10.0)
-            let expectedResults = seq {"some";"text"}
-            
-            do! Completion.expectCompletion testDocPath position expectedResults resetWorkspaceHook
+
+            do! Completion.expectCompletion testDocPath position <| seq {"some";"text"} <| None
+
+            do! resetConfig()
         
-            do! Completion.expectCompletion testDocPath position Completion.DefaultExpectedTerms resetWorkspaceHook
+            do! Completion.expectCompletion testDocPath position Completion.DefaultExpectedTerms None
         }
     ]

--- a/src/vscode/contextly/test/InvalidSchema.test.fs
+++ b/src/vscode/contextly/test/InvalidSchema.test.fs
@@ -1,0 +1,27 @@
+module Contextly.VsCodeExtension.Tests.InvalidSchema
+
+open Fable.Mocha
+open Fable.Import.VSCode
+open Initialize
+
+let tests =
+    testList "Invalid Schema Tests" [
+        testCaseAsync "Should recover from an invalid schema" <| async {
+            let newPath = $".contextly/invalid_schema.yml"
+            do! updateConfig newPath
+
+            do! VsCodeCommands.initialize() |> Promise.Ignore
+            
+            do! Promise.sleep 500
+
+            let resetWorkspaceHook = Some (fun _ -> promise {do! resetConfig()})
+
+            let testDocPath = "../test/fixtures/simple_workspace/test.txt"
+            let position = vscode.Position.Create(0.0, 10.0)
+            let expectedResults = seq {"some";"text"}
+            
+            do! Completion.expectCompletion testDocPath position expectedResults resetWorkspaceHook
+        
+            do! Completion.expectCompletion testDocPath position Completion.DefaultExpectedTerms resetWorkspaceHook
+        }
+    ]

--- a/src/vscode/contextly/test/Main.test.fs
+++ b/src/vscode/contextly/test/Main.test.fs
@@ -2,14 +2,23 @@ module Contextly.VsCodeExtension.Tests.Main
 
 open Fable.Mocha
 open Fable.Core
+open Fable.Core.JS
 
 // Import mocha explicitly.  Fable.Mocha assumes running via the mocha CLI which imports mocha _implicitly_
 [<Import("*", from="mocha")>]
 let Mocha: obj = jsNative
 
+[<Emit("afterEach($0)")>]
+let afterEach (callback: unit -> Promise<unit>):unit = jsNative
+
+afterEach(fun () -> promise {
+    do! Initialize.resetConfig()
+})
+
 Fable.Mocha.Mocha.runTests <| testList "All" [
     Extension.tests
     Completion.tests
     Initialize.tests
+    InvalidSchema.tests
 ] |> ignore
 

--- a/src/vscode/contextly/test/Main.test.fs
+++ b/src/vscode/contextly/test/Main.test.fs
@@ -2,17 +2,13 @@ module Contextly.VsCodeExtension.Tests.Main
 
 open Fable.Mocha
 open Fable.Core
-open Fable.Core.JS
 
 // Import mocha explicitly.  Fable.Mocha assumes running via the mocha CLI which imports mocha _implicitly_
 [<Import("*", from="mocha")>]
 let Mocha: obj = jsNative
 
-[<Emit("afterEach($0)")>]
-let afterEach (callback: unit -> Promise<unit>):unit = jsNative
-
-afterEach(fun () -> promise {
-    do! Initialize.resetConfig()
+Helpers.afterEach("reset config", fun () -> promise {
+    do! Helpers.resetConfig()
 })
 
 Fable.Mocha.Mocha.runTests <| testList "All" [

--- a/src/vscode/contextly/test/fixtures/simple_workspace/.contextly/invalid_schema.yml
+++ b/src/vscode/contextly/test/fixtures/simple_workspace/.contextly/invalid_schema.yml
@@ -1,0 +1,7 @@
+# Invalid definitions.  `example` is an unknown key - it should be `examples`
+contexts:
+  - terms:
+    - name: invalidTerm
+      definition: A term with an invalid schema in the definitions.yml
+      example:
+        - This should be in the `examples` key.


### PR DESCRIPTION
Previously, if the definitions file could not be parsed, contextly would lose the definitions and never recover them, even if the file was fixed so it should be parseable.

This PR introduces more resiliency so that if the file can't be parsed, on startup, after an edit, or after a config setting change to a new file (which can't be parsed) a warning is displayed to the user, and the definitions are reset.  In all cases, when the issue is fixed (either due to a config change, or correcting the file content), the content of the fixed file now becomes the 'live' definitions.